### PR TITLE
Make BaseLoading display nothing when no error message was identified…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `BaseLoading` display nothing when no error message was identified and is not loading anymore.
 
 ## [0.3.1] - 2018-12-06
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.3.2] - 2018-12-07
 ### Fixed
 - `BaseLoading` display nothing when no error message was identified and is not loading anymore.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "my-account-commons",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "title": "MyAccount Commons",
   "defaultLocale": "pt-BR",
   "description": "Shared components used to build ne MyAccounts pages",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.1",
+  "version": "0.3.2",
   "dependencies": {
     "babel-eslint": "^10.0.1",
     "eslint": "^5.9.0",

--- a/react/components/BaseLoading.js
+++ b/react/components/BaseLoading.js
@@ -47,22 +47,22 @@ class BaseLoading extends Component {
       }
     }
 
+    const content = isLoading
+      ? children
+      : errorMessageId && (
+          <div className="mt7">
+            <ReloadableError
+              errorId={errorMessageId}
+              onReload={this.handleReload}
+            />
+          </div>
+        )
+
     return (
       <ContentWrapper
         namespace={namespace || 'vtex-base-loading'}
         {...headerConfig}>
-        {() => (
-          <Fragment>
-            {isLoading ? (
-              children
-            ) : (
-              <ReloadableError
-                errorId={errorMessageId}
-                onReload={this.handleReload}
-              />
-            )}
-          </Fragment>
-        )}
+        {() => <Fragment>{content}</Fragment>}
       </ContentWrapper>
     )
   }

--- a/react/components/ReloadableError.js
+++ b/react/components/ReloadableError.js
@@ -5,16 +5,14 @@ import { Alert } from 'vtex.styleguide'
 
 const ReloadableError = ({ errorId, onReload, intl }) => {
   return (
-    <div className="mt7">
-      <Alert
-        type="error"
-        action={{
-          label: intl.formatMessage({ id: 'alert.reload' }),
-          onClick: onReload,
-        }}>
-        {intl.formatMessage({ id: errorId })}
-      </Alert>
-    </div>
+    <Alert
+      type="error"
+      action={{
+        label: intl.formatMessage({ id: 'alert.reload' }),
+        onClick: onReload,
+      }}>
+      {intl.formatMessage({ id: errorId })}
+    </Alert>
   )
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
- Make BaseLoading display nothing when no error message was identified and is not loading anymore.

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
