### PR TITLE
Bump styleguide version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.8.0] - 2019-01-31
 ### Changed
 - `vtex.styleguide` to version 8
 - `ContentWrapper` inside alignment and padding on small screens. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- `vtex.styleguide` to version 8
+- `ContentWrapper` inside alignment and padding on small screens. 
 
 ## [0.7.0] - 2019-01-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `ContentWrapper` inside alignment and padding on small screens. 
 
 ## [0.7.0] - 2019-01-22
+### Changed
+- Bumps messages builder major
 
 ## [0.6.0] - 2019-01-07
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -18,6 +18,6 @@
     "postreleasy": "vtex publish --verbose"
   },
   "dependencies": {
-    "vtex.styleguide": "7.x"
+    "vtex.styleguide": "8.x"
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "my-account-commons",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "title": "MyAccount Commons",
   "defaultLocale": "pt-BR",
   "description": "Shared components used to build ne MyAccounts pages",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.7.0",
+  "version": "0.8.0",
   "dependencies": {
     "babel-eslint": "^10.0.1",
     "eslint": "^5.9.0",

--- a/react/components/ContentWrapper.js
+++ b/react/components/ContentWrapper.js
@@ -51,8 +51,7 @@ class ContentWrapper extends Component {
             {headerContent}
           </PageHeader>
         </header>
-        <main
-          className={`vtex-account__page-body ${namespace} w-100 pa4-s`}>
+        <main className={`vtex-account__page-body ${namespace} w-100 pa4-s`}>
           {shouldShowError && (
             <div className="w-100 flex justify-around">
               <div className="w-50-ns w-80-s">

--- a/react/components/ContentWrapper.js
+++ b/react/components/ContentWrapper.js
@@ -34,7 +34,7 @@ class ContentWrapper extends Component {
     const { shouldShowError } = this.state
 
     return (
-      <section className="vtex-account__page w-100 w-80-m pa6">
+      <section className="vtex-account__page w-100 w-80-m">
         <header>
           <PageHeader
             title={title || intl.formatMessage({ id: titleId })}
@@ -52,12 +52,16 @@ class ContentWrapper extends Component {
           </PageHeader>
         </header>
         <main
-          className={`vtex-account__page-body ${namespace} center w-100 pt6 flex justify-around`}>
+          className={`vtex-account__page-body ${namespace} w-100 pa4-s`}>
           {shouldShowError && (
-            <GenericError
-              onDismiss={this.handleDismissError}
-              errorId="alert.unknownError"
-            />
+            <div className="w-100 flex justify-around">
+              <div className="w-50-ns w-80-s">
+                <GenericError
+                  onDismiss={this.handleDismissError}
+                  errorId="alert.unknownError"
+                />
+              </div>
+            </div>
           )}
           {children({ handleError: this.handleError })}
         </main>


### PR DESCRIPTION
#### What is the purpose of this pull request?
- Updates the version of the `vtex.styleguide` to 8.x
- Removes the `ContentWrapper` inside alignment, giving more flexibility to users.

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Requires change to documentation, which has been updated accordingly.
