### PR TITLE
Fix pickup order readiness conditional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Pickup order readiness conditional.
+
 ## [0.10.1] - 2019-08-07
 
 ### Fixed

--- a/react/components/ProgressBar/utils.ts
+++ b/react/components/ProgressBar/utils.ts
@@ -82,5 +82,11 @@ export function generatePackageProgressBarStates(
 export function isOrderReadyToPickUp(packages: any) {
   if (packages == null || packages.length === 0) return false
 
-  return packages.every((pkg: any) => pkg.deliveryChannel === 'pickup-in-point')
+  return packages.every((item: any) => {
+    const isPickUp = item.deliveryChannel === 'pickup-in-point'
+    const isReadyToPickUp =
+      !item.shippingEstimateDate ||
+      Date.now() >= new Date(item.shippingEstimateDate).getTime()
+    return isPickUp && isReadyToPickUp
+  })
 }


### PR DESCRIPTION
Related to https://github.com/vtex/my-orders/pull/186

#### What is the purpose of this pull request?

https://app.clubhouse.io/vtex/story/18053/ajuste-da-label-do-myorders-ao-inves-de-enviado-para-pedidos-de-pickup-colocar-pronto-para-retirada

#### What problem is this solving?

Fix wrong status badge when a pickup order is not yet delivered to the pickup point.

#### How should this be manually tested?

1. Create a new order with delivery channel set to `pickup-in-point`.
2. In OMS, define a shipping estimate date and invoice the order 
3. Go to the my order details page and check the status badge saying 'shipped' instead of 'ready for pickup'

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/12702016/63377968-8d3ace80-c367-11e9-853b-857424d061d0.png)

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
