### PR TITLE
Add hideBackButton prop @0.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `hideBackButton` prop to ContentWrapper.
+
 ## [0.11.1] - 2020-06-15
 
 ### Fixed

--- a/react/components/ContentWrapper.js
+++ b/react/components/ContentWrapper.js
@@ -30,24 +30,26 @@ class ContentWrapper extends Component {
       history,
       headerContent,
       namespace,
+      hideBackButton = false,
     } = this.props
     const { shouldShowError } = this.state
+
+    const backButtonConfigs = {
+      linkLabel: backButton
+        ? backButton.title
+          ? backButton.title
+          : intl.formatMessage({ id: backButton.titleId })
+        : intl.formatMessage({ id: 'commons.back' }),
+      onLinkClick: () => history.push(backButton ? backButton.path : '/'),
+    }
 
     return (
       <section className="vtex-account__page w-100 w-80-m">
         <header>
           <PageHeader
             title={title || intl.formatMessage({ id: titleId })}
-            linkLabel={
-              backButton
-                ? backButton.title
-                  ? backButton.title
-                  : intl.formatMessage({ id: backButton.titleId })
-                : intl.formatMessage({ id: 'commons.back' })
-            }
-            onLinkClick={() =>
-              history.push(backButton ? backButton.path : '/')
-            }>
+            {...(!hideBackButton && backButtonConfigs)}
+          >
             {headerContent}
           </PageHeader>
         </header>
@@ -81,6 +83,7 @@ ContentWrapper.propTypes = {
     path: PropTypes.string.isRequired,
   }),
   history: ReactRouterPropTypes.history.isRequired,
+  hideBackButton: PropTypes.bool,
   headerContent: PropTypes.node,
 }
 

--- a/react/package.json
+++ b/react/package.json
@@ -27,7 +27,7 @@
     "eslint": "^5.16.0",
     "eslint-config-vtex-react": "^4.0.0",
     "prettier": "^1.17.0",
-    "typescript": "3.5.2"
+    "typescript": "3.8.3"
   },
   "version": "0.11.1"
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5183,10 +5183,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.5.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
-  integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==
+typescript@3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 typescript@^3.3.3333:
   version "3.5.3"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add `hideBackButton` prop to enable hiding the back button when needed.

#### What problem is this solving?
Enable hiding the button at the profile page as it is not needed.

#### How should this be manually tested?
https://cobasi.myvtex.com/_secure/account?workspace=profile#/profile

#### Screenshots or example usage
Before:
![image](https://user-images.githubusercontent.com/27328184/85438872-cbde7e00-b562-11ea-8f5d-311cddb993f0.png)

After:
![image](https://user-images.githubusercontent.com/27328184/85438703-a3ef1a80-b562-11ea-8eba-6fcfb35b0e4f.png)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
