### PR TITLE
Fix mobile back button@1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+#### Fixed
+
+- Prevent back button from being hidden when in mobile phones.
+
 ## [1.5.0] - 2020-07-24
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -10,9 +10,7 @@
     "messages": "1.x",
     "docs": "0.x"
   },
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "mustUpdateAt": "2019-04-02",
   "scripts": {
     "postreleasy": "vtex publish --verbose"

--- a/react/components/ContentWrapper.js
+++ b/react/components/ContentWrapper.js
@@ -46,12 +46,22 @@ class ContentWrapper extends Component {
     return (
       <section className="vtex-account__page w-100 w-80-m">
         <header>
-          <PageHeader
-            title={title || intl.formatMessage({ id: titleId })}
-            {...(!hideBackButton && backButtonConfigs)}
-          >
-            {headerContent}
-          </PageHeader>
+          <div className="db dn-m">
+            <PageHeader
+              title={title || intl.formatMessage({ id: titleId })}
+              {...backButtonConfigs}
+            >
+              {headerContent}
+            </PageHeader>
+          </div>
+          <div className="db-m dn">
+            <PageHeader
+              title={title || intl.formatMessage({ id: titleId })}
+              {...(!hideBackButton && backButtonConfigs)}
+            >
+              {headerContent}
+            </PageHeader>
+          </div>
         </header>
         <main className={`vtex-account__page-body ${namespace} w-100 pa4-s`}>
           {shouldShowError && (
@@ -87,4 +97,4 @@ ContentWrapper.propTypes = {
   headerContent: PropTypes.node,
 }
 
-export default withRouter(injectIntl(ContentWrapper))
+export default injectIntl(withRouter(ContentWrapper))

--- a/react/utils.js
+++ b/react/utils.js
@@ -49,7 +49,7 @@ function reduceBundleItems(items) {
 
       if (item.bundleItems && item.bundleItems.length > 0) {
         acc = acc.concat(
-          item.bundleItems.map(bundleItem =>
+          item.bundleItems.map((bundleItem) =>
             addBundleItemFlagAndParentItemQuantity(item, bundleItem)
           )
         )


### PR DESCRIPTION
## Same as #38 but at 1.x 

#### What is the purpose of this pull request?
Prevent back button from being hidden when in mobile phones.

#### What problem is this solving?
Without it, people are unable to exit my-account. [See](https://vtex.slack.com/archives/C91LXBHLK/p1594402249014400).

#### How should this be manually tested?
https://villar--storecomponents.myvtex.com/account#/profile

#### Screenshots or example usage
It stills hides in desktops, but appears in mobile phones.
![image](https://user-images.githubusercontent.com/27328184/89290900-f1fe4000-d62f-11ea-857a-6e4f4008324c.png)

![image](https://user-images.githubusercontent.com/27328184/89290926-faef1180-d62f-11ea-82f0-9a69fa37446e.png)

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
