### PR TITLE
Fixing a bug in estimateShipping when there is no unit in shippingEstimate

### DIFF
--- a/react/__tests__/utils.js
+++ b/react/__tests__/utils.js
@@ -1,0 +1,70 @@
+import utils from '../utils'
+
+describe('estimateShipping', () => {
+  it('with unit as days should return the correct payload', () => {
+    const currentDate = new Date()
+    const mockDeliveryPackage = {
+      shippingEstimate: '1d',
+      shippingEstimateDate: currentDate,
+    }
+
+    const response = utils.estimateShipping(mockDeliveryPackage)
+    expect(response.date).toBe(currentDate)
+    expect(response.isEstimateInHoursOrMinutes).toBe(false)
+  })
+
+  it('with unit as hours should return the correct payload', () => {
+    const currentDate = new Date()
+    const mockDeliveryPackage = {
+      shippingEstimate: '1h',
+      shippingEstimateDate: currentDate,
+    }
+
+    const response = utils.estimateShipping(mockDeliveryPackage)
+    expect(response.date).toBe(currentDate)
+    expect(response.isEstimateInHoursOrMinutes).toBe(true)
+  })
+
+  it('with only shippingEstimate the correct payload', () => {
+    const currentDate = new Date()
+    const value = '1'
+    const type = 'h'
+    const mockDeliveryPackage = {
+      shippingEstimate: `${value}${type}`,
+    }
+
+    const response = utils.estimateShipping(mockDeliveryPackage)
+    expect(response.unit).toBe(parseInt(value))
+    expect(response.type).toBe(type)
+    expect(response.label).not.toBeNull()
+  })
+
+  it('with only shippingEstimateDate returns the correct payload', () => {
+    const currentDate = new Date()
+    const mockDeliveryPackage = {
+      shippingEstimateDate: currentDate,
+    }
+
+    const response = utils.estimateShipping(mockDeliveryPackage)
+    expect(response.date).toBe(currentDate)
+  })
+
+  it('without info returns null', () => {
+    const mockedDeliveryPackage = {}
+
+    const response = utils.estimateShipping(mockedDeliveryPackage)
+    expect(response).toBeNull()
+  })
+
+  it('with empty shippingEstimate unit should return shippingEstimateDate', () => {
+    const currentDate = new Date()
+    const mockDeliveryPackage = {
+      shippingEstimate: '1',
+      shippingEstimateDate: currentDate,
+    }
+
+    const response = utils.estimateShipping(mockDeliveryPackage)
+
+    expect(response.date).toBe(currentDate)
+  })
+})

--- a/react/__tests__/utils.js
+++ b/react/__tests__/utils.js
@@ -9,6 +9,7 @@ describe('estimateShipping', () => {
     }
 
     const response = utils.estimateShipping(mockDeliveryPackage)
+
     expect(response.date).toBe(currentDate)
     expect(response.isEstimateInHoursOrMinutes).toBe(false)
   })
@@ -21,6 +22,7 @@ describe('estimateShipping', () => {
     }
 
     const response = utils.estimateShipping(mockDeliveryPackage)
+
     expect(response.date).toBe(currentDate)
     expect(response.isEstimateInHoursOrMinutes).toBe(true)
   })
@@ -34,6 +36,7 @@ describe('estimateShipping', () => {
     }
 
     const response = utils.estimateShipping(mockDeliveryPackage)
+
     expect(response.unit).toBe(parseInt(value))
     expect(response.type).toBe(type)
     expect(response.label).not.toBeNull()
@@ -46,6 +49,7 @@ describe('estimateShipping', () => {
     }
 
     const response = utils.estimateShipping(mockDeliveryPackage)
+
     expect(response.date).toBe(currentDate)
   })
 
@@ -53,6 +57,7 @@ describe('estimateShipping', () => {
     const mockedDeliveryPackage = {}
 
     const response = utils.estimateShipping(mockedDeliveryPackage)
+
     expect(response).toBeNull()
   })
 

--- a/react/utils.js
+++ b/react/utils.js
@@ -8,36 +8,51 @@ function estimateShipping(deliveryPackage) {
     shippingEstimateDate: slaShippingEstimateDate,
   } = deliveryPackage
 
-  let shippingEstimate
-  if (slaShippingEstimateDate) {
-    const isEstimateInHoursOrMinutes =
-      slaShippingEstimate.match(/\d+|[a-zA-Z]+/g)[1].indexOf('h') !== -1 ||
-      slaShippingEstimate.match(/\d+|[a-zA-Z]+/g)[1].indexOf('m') !== -1
+  if (!slaShippingEstimate) {
+    return slaShippingEstimateDate != null
+      ? {
+          date: slaShippingEstimateDate,
+        }
+      : null
+  }
 
-    shippingEstimate = {
+  const shippingEstimateParts = slaShippingEstimate.match(/\d+|[a-zA-Z]+/g)
+
+  // There's a bug in the API that makes shippingEstimate not have a unit.
+  // This is the case this if is fixing
+  if (!shippingEstimateParts || shippingEstimateParts.length <= 1) {
+    return {
       date: slaShippingEstimateDate,
-      isEstimateInHoursOrMinutes: isEstimateInHoursOrMinutes,
-    }
-  } else if (slaShippingEstimate) {
-    const shippingEstimateParts = slaShippingEstimate.match(/\d+|[a-zA-Z]+/g)
-
-    const number = parseInt(shippingEstimateParts[0])
-    const type = shippingEstimateParts[1]
-
-    const label = (
-      <FormattedMessage
-        id={`order.shippingEstimate.${type}`}
-        values={{ timeAmount: number }}
-      />
-    )
-
-    shippingEstimate = {
-      unit: number,
-      type: type,
-      label: label,
     }
   }
-  return shippingEstimate
+
+  const estimateValue = shippingEstimateParts[0]
+  const estimateType = shippingEstimateParts[1]
+
+  if (slaShippingEstimateDate) {
+    const isEstimateInHoursOrMinutes =
+      estimateType.indexOf('h') !== -1 || estimateType.indexOf('m') !== -1
+
+    return {
+      date: slaShippingEstimateDate,
+      isEstimateInHoursOrMinutes,
+    }
+  }
+
+  const estimateValueInt = parseInt(estimateValue)
+
+  const label = (
+    <FormattedMessage
+      id={`order.shippingEstimate.${estimateType}`}
+      values={{ timeAmount: estimateValueInt }}
+    />
+  )
+
+  return {
+    unit: estimateValueInt,
+    type: estimateType,
+    label: label,
+  }
 }
 
 function reduceBundleItems(items) {

--- a/react/utils.js
+++ b/react/utils.js
@@ -18,7 +18,7 @@ function estimateShipping(deliveryPackage) {
 
   const shippingEstimateParts = slaShippingEstimate.match(/\d+|[a-zA-Z]+/g)
 
-  // There's a bug in the API that makes shippingEstimate not have a unit.
+  // There's a bug in the API that makes shippingEstimate not to have a unit.
   // This is the case this if is fixing
   if (!shippingEstimateParts || shippingEstimateParts.length <= 1) {
     return {


### PR DESCRIPTION
This PR fixes https://vtex-dev.atlassian.net/browse/POST-380

The API sometimes saves `shippingEstimate` without unit sign breaking the old code.

I'm also refactoring the code and adding test coverage to know for sure that no previous behavior was broken.

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.