### PR TITLE
Add getCurrentProgressBarState function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `getCurrentProgressBarState` function.
+
 ## [1.5.2] - 2020-09-10
 
 ### Fixed

--- a/react/ProgressBarBundle.js
+++ b/react/ProgressBarBundle.js
@@ -5,6 +5,7 @@ import {
 import {
   generatePackageProgressBarStates,
   generateProgressBarStates,
+  getCurrentProgressBarState
 } from './components/ProgressBar/utils'
 import OrderStatus from './components/ProgressBar/OrderStatus'
 import ProgressBar from './components/ProgressBar/ProgressBar'
@@ -21,6 +22,7 @@ const constants = {
 const utils = {
   generatePackageProgressBarStates,
   generateProgressBarStates,
+  getCurrentProgressBarState
 }
 
 export default {

--- a/react/components/ProgressBar/utils.ts
+++ b/react/components/ProgressBar/utils.ts
@@ -39,7 +39,9 @@ export function generateProgressBarStates(
 export function getCurrentProgressBarState(status: string, packages: any) {
   const currentProgressIndex = getOrderProgress(status, packages)
 
-  return generateProgressBarStates(progressBarStates, currentProgressIndex, packages)[currentProgressIndex]?.label
+  const progressBarStates = generateProgressBarStates(progressBarStates, currentProgressIndex, packages)
+
+  return progressBarStates[currentProgressIndex]?.label
 }
 
 export function isDelivered(packages: any) {

--- a/react/components/ProgressBar/utils.ts
+++ b/react/components/ProgressBar/utils.ts
@@ -1,4 +1,5 @@
-import { FIFTH_STEP, THIRD_STEP } from './constants'
+import { FIFTH_STEP, progressBarStates, THIRD_STEP } from './constants'
+import getOrderProgress from './getOrderProgress'
 
 export function generateProgressBarStates(
   progressBarStates: any[],
@@ -35,11 +36,18 @@ export function generateProgressBarStates(
   })
 }
 
+export function getCurrentProgressBarState(status: string, packages: any) {
+  const currentProgressIndex = getOrderProgress(status, packages)
+
+  return generateProgressBarStates(progressBarStates, currentProgressIndex, packages)[currentProgressIndex]?.label
+}
+
 export function isDelivered(packages: any) {
-  let isDelivered = true
-  if (packages.length === 0) {
-    isDelivered = false
+  if (packages == null || packages.length === 0) {
+    return false
   }
+
+  let isDelivered = true
   packages.map((pack: any) => {
     if (
       !pack.package ||
@@ -50,6 +58,7 @@ export function isDelivered(packages: any) {
       return
     }
   })
+
   return isDelivered
 }
 

--- a/react/components/ProgressBar/utils.ts
+++ b/react/components/ProgressBar/utils.ts
@@ -39,9 +39,9 @@ export function generateProgressBarStates(
 export function getCurrentProgressBarState(status: string, packages: any) {
   const currentProgressIndex = getOrderProgress(status, packages)
 
-  const progressBarStates = generateProgressBarStates(progressBarStates, currentProgressIndex, packages)
+  const generatedProgressBarStates = generateProgressBarStates(progressBarStates, currentProgressIndex, packages)
 
-  return progressBarStates[currentProgressIndex]?.label
+  return generatedProgressBarStates[currentProgressIndex]?.label
 }
 
 export function isDelivered(packages: any) {

--- a/react/package.json
+++ b/react/package.json
@@ -24,7 +24,7 @@
     "@vtex/delivery-packages": "^2.17.0",
     "@vtex/test-tools": "^3.1.0",
     "apollo-client": "^2.5.1",
-    "typescript": "3.8.3"
+    "typescript": "3.9.7"
   },
   "version": "1.5.2"
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5309,10 +5309,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 typescript@^3.7.3:
   version "3.9.6"


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add function to get the current state that an order is according to the Progress Bar labels.

#### How should this be manually tested?

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
