### PR TITLE
Using only output packages when considering if order is delivered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `isDelivered` function only considers output packages.
+
 ## [0.15.0] - 2021-03-17
 
 ### Added

--- a/react/__tests__/getOrderProgress.test.ts
+++ b/react/__tests__/getOrderProgress.test.ts
@@ -144,6 +144,7 @@ describe('getOrderProgress', () => {
         package: {
           trackingNumber: '423243423',
           trackingUrl: 'http://ufcg.edu.br',
+          type: 'Output',
           courierStatus: {
             status: 'unknown',
             finished: false,

--- a/react/components/ProgressBar/utils.ts
+++ b/react/components/ProgressBar/utils.ts
@@ -55,26 +55,13 @@ export function isDelivered(packages: any) {
     return false
   }
 
-  let isDelivered = true
+  if (packages == null || packages.length === 0) {
+    return false
+  }
 
-  var outputPackages = packages.filter(
-    (pack: any) => pack?.package?.type === OutputPackageType
+  return packages.some(
+    (pack: any) => pack?.package?.type === OutputPackageType && pack?.package?.courierStatus?.finished)
   )
-
-  if (outputPackages.length === 0) return false
-
-  outputPackages.map((pack: any) => {
-    if (
-      !pack.package ||
-      !pack.package.courierStatus ||
-      pack.package.courierStatus.finished === false
-    ) {
-      isDelivered = false
-      return
-    }
-  })
-
-  return isDelivered
 }
 
 export function generatePackageProgressBarStates(

--- a/react/components/ProgressBar/utils.ts
+++ b/react/components/ProgressBar/utils.ts
@@ -56,18 +56,23 @@ export function isDelivered(packages: any) {
   }
 
   let isDelivered = true
-  packages
-    .filter((pack: any) => pack?.type === OutputPackageType)
-    .map((pack: any) => {
-      if (
-        !pack.package ||
-        !pack.package.courierStatus ||
-        pack.package.courierStatus.finished === false
-      ) {
-        isDelivered = false
-        return
-      }
-    })
+
+  var outputPackages = packages.filter(
+    (pack: any) => pack?.package?.type === OutputPackageType
+  )
+
+  if (outputPackages.length === 0) return false
+
+  outputPackages.map((pack: any) => {
+    if (
+      !pack.package ||
+      !pack.package.courierStatus ||
+      pack.package.courierStatus.finished === false
+    ) {
+      isDelivered = false
+      return
+    }
+  })
 
   return isDelivered
 }

--- a/react/components/ProgressBar/utils.ts
+++ b/react/components/ProgressBar/utils.ts
@@ -1,6 +1,8 @@
 import { FIFTH_STEP, progressBarStates, THIRD_STEP } from './constants'
 import getOrderProgress from './getOrderProgress'
 
+const OutputPackageType = 'Output'
+
 export function generateProgressBarStates(
   progressBarStates: any[],
   currentState: number,
@@ -39,7 +41,11 @@ export function generateProgressBarStates(
 export function getCurrentProgressBarState(status: string, packages: any) {
   const currentProgressIndex = getOrderProgress(status, packages)
 
-  const generatedProgressBarStates = generateProgressBarStates(progressBarStates, currentProgressIndex, packages)
+  const generatedProgressBarStates = generateProgressBarStates(
+    progressBarStates,
+    currentProgressIndex,
+    packages
+  )
 
   return generatedProgressBarStates[currentProgressIndex]?.label
 }
@@ -50,16 +56,18 @@ export function isDelivered(packages: any) {
   }
 
   let isDelivered = true
-  packages.map((pack: any) => {
-    if (
-      !pack.package ||
-      !pack.package.courierStatus ||
-      pack.package.courierStatus.finished === false
-    ) {
-      isDelivered = false
-      return
-    }
-  })
+  packages
+    .filter((pack: any) => pack?.type === OutputPackageType)
+    .map((pack: any) => {
+      if (
+        !pack.package ||
+        !pack.package.courierStatus ||
+        pack.package.courierStatus.finished === false
+      ) {
+        isDelivered = false
+        return
+      }
+    })
 
   return isDelivered
 }

--- a/react/components/ProgressBar/utils.ts
+++ b/react/components/ProgressBar/utils.ts
@@ -55,13 +55,13 @@ export function isDelivered(packages: any) {
     return false
   }
 
-  if (packages == null || packages.length === 0) {
-    return false
-  }
-
-  return packages.some(
-    (pack: any) => pack?.package?.type === OutputPackageType && pack?.package?.courierStatus?.finished)
+  const isDelivered = !packages.some(
+    (pack: any) =>
+      pack?.package?.type === OutputPackageType &&
+      !pack?.package?.courierStatus?.finished
   )
+
+  return isDelivered
 }
 
 export function generatePackageProgressBarStates(


### PR DESCRIPTION
#### What is the purpose of this pull request?
If the order was considered delivered and an input invoice is added, the order status rollbacks to "handling". This PR fixes it by using only output invoices to consider if an order is delivered or not. 

#### What problem is this solving?
[Ref thread](https://vtex.slack.com/archives/G016AGYHTV2/p1679583896817669?thread_ts=1677253016.660479&cid=G016AGYHTV2)

#### How should this be manually tested?
1- Create and order in the [qastore](qastore.myvtex.com)
2- Move it up until :invoiced:
3- Deliver the item using the UI
4- Return the item
5- Go to My Accounts on [this workspace](https://fixisdelivered--qastore.myvtex.com/) and the order should still be considered delivered

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
