### PR TITLE
Fixed a spanish string for uniformity across other repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Spanish translation.
+
 ## [1.6.1] - 2023-04-05
 
 ### Fixed

--- a/messages/es.json
+++ b/messages/es.json
@@ -3,7 +3,7 @@
   "alert.unauthenticated": "Debe estar autenticado para continuar con esta acción.",
   "alert.reload": "Recargar",
   "alert.unknownError": "Se produjo un error, inténtalo de nuevo.",
-  "commons.back": "Regreso",
+  "commons.back": "Atrás",
   "progressBar.package.progress": "Estado del paquete",
   "progressBar.order.status": "Estado del pedido"
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

It relates to task [LOC-11299](https://vtex-dev.atlassian.net/browse/LOC-11299). Fixes a Spanish string that is supposed to be "Atrás".

#### Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.


[LOC-11299]: https://vtex-dev.atlassian.net/browse/LOC-11299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ