### PR TITLE
[Fix][OMS-4482] Fix isDelivered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `isDelivered` function returns `false` when is not possible to tell whether an invoice is `input` or `output`.
+
 ## [1.7.0] - 2023-06-01
 
 ### Fixed

--- a/react/components/ProgressBar/getOrderProgress.ts
+++ b/react/components/ProgressBar/getOrderProgress.ts
@@ -51,6 +51,7 @@ function isCarrierHandling(packages: any) {
 export default function getOrderProgress(status: string, packages: any) {
   let progress = statusMap[status]
   const isPickup = isOrderPickUp(packages)
+
   if (progress === FOURTH_STEP) {
     if (
       isDelivered(packages) ||
@@ -60,5 +61,6 @@ export default function getOrderProgress(status: string, packages: any) {
       progress = FIFTH_STEP
     }
   }
+
   return progress
 }

--- a/react/components/ProgressBar/utils.ts
+++ b/react/components/ProgressBar/utils.ts
@@ -56,9 +56,11 @@ export function isDelivered(packages: any) {
   }
 
   const isDelivered = !packages.some(
-    (pack: any) =>
-      pack?.package?.type === OutputPackageType &&
-      !pack?.package?.courierStatus?.finished
+    (pack: any) => {
+      if (!pack?.package) return true // In case you can't tell whether the invoice is input or output, the order as a whole should be considered as not delivered.
+
+      return pack?.package?.type === OutputPackageType &&
+      !pack?.package?.courierStatus?.finished}
   )
 
   return isDelivered


### PR DESCRIPTION
> Jira: https://vtex-dev.atlassian.net/browse/OMS-4482

#### What is the purpose of this pull request?

Fix a corner case for IsDelivered function.

<!--- Describe your changes in detail. -->

#### What problem is this solving?

Resumo da ópera: um tempo atrás a gente tinha um problema que, caso existisse uma invoice de input sem  courierStatus.finished, o pedido voltava de status no my-orders, e ficava como se não estivesse entregue. Foi feito um [PR](https://github.com/vtex-apps/my-account-commons/pull/69/files) com o intuito de resolver isso, e a regra que a gente escolheu na época foi:

`Se não existir no pedido pelo menos um pacote de output que não foi entregue, o pedido como um todo é dado como entregue.`

Por alguma razão, para esse pedido específico, nessa parte do código, a gente não consegue dizer se a invoice é de input ou output, e portanto, devido à regra acima, o pedido era dado como entregue. Pra saber especificamente por que isso está acontecendo, a gente teria que descer mais ainda no código, depois de ter passado pelo my-orders e pelo my-account-commons, e ir pro delivery-packages, e ver o que exatamente tem de especial nesse pedido pra isso acontecer. Mas acho que o ajuste que eu proponho no PR é razoavelmente seguro, e vai na linha de, caso a gente não consiga dizer se determinada invoice é de input ou output, a gente assume que o pedido como um todo não foi entregue.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

😞 

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
