### PR TITLE
Add a className to the header element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Add with the namespace to enable page Header customization at my account.
+
 ## [1.7.1] - 2023-08-15
 
 ### Fixed

--- a/react/components/ContentWrapper.js
+++ b/react/components/ContentWrapper.js
@@ -45,7 +45,7 @@ class ContentWrapper extends Component {
 
     return (
       <section className="vtex-account__page w-100 w-80-m">
-        <header>
+        <header className={`${namespace}__header`}>
           <div className="db dn-m">
             <PageHeader
               title={title || intl.formatMessage({ id: titleId })}


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add a class to the <header> element, so users will be able to customize a page header layout for a particular page (e.g. My Account / Addresses)

#### Screenshots or example usage

![image](https://github.com/vtex-apps/my-account-commons/assets/98008460/f457dd41-87d2-481a-bbf0-ed7ba8816f33)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
